### PR TITLE
Commit update to repository

### DIFF
--- a/.github/workflows/update_and_post.yaml
+++ b/.github/workflows/update_and_post.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 
 jobs:
-  render-markdown:
+  render-and-post:
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +40,23 @@ jobs:
 
     - name: Render CRAN downloads RMD
       run: Rscript -e "rmarkdown::render('CRANdownloads.Rmd')"
+
+    - name: Copy to GH Pages directory
+      run: |
+        mkdir summary
+        cp CRANdownloads.html summary/
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+        
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: "summary"
+        
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
 
     - name: Commit to repository
       run: |

--- a/.github/workflows/update_rmd.yaml
+++ b/.github/workflows/update_rmd.yaml
@@ -44,6 +44,6 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git add --all
-        git commit --allow-empty -m "[auto] Update CRAN downloads $(TZ=America/New_York date +'%Y-%m-%d %H:%M')"
+        git add CRANdownloads.html
+        git commit -m "[auto] Update CRAN downloads $(TZ=America/New_York date +'%Y-%m-%d %H:%M')"
         git push

--- a/.github/workflows/update_rmd.yaml
+++ b/.github/workflows/update_rmd.yaml
@@ -1,4 +1,5 @@
 on:
+  push:
   schedule:
     - cron: '0 0 1 * *'
   workflow_dispatch:

--- a/.github/workflows/update_rmd.yaml
+++ b/.github/workflows/update_rmd.yaml
@@ -8,31 +8,42 @@ name: Render CRAN package downloads
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: write
+
 jobs:
-    render-markdown:
-        runs-on: ubuntu-latest
+  render-markdown:
+    runs-on: ubuntu-latest
 
-        steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-        - name: Set up R
-          uses: r-lib/actions/setup-r@v2
-          with:
-            use-public-rspm: true
+    - name: Set up R
+      uses: r-lib/actions/setup-r@v2
+      with:
+        use-public-rspm: true
 
-        - name: Set up R packages
-          uses: r-lib/actions/setup-r-dependencies@v2
-          with:
-            packages:
-                any::knitr
-                any::rmarkdown
-                any::cranlogs
-                any::data.table
-                any::ggplot2
-                any::plotly
-                any::hrbrthemes
-                any::extrafont
+    - name: Set up R packages
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        packages:
+            any::knitr
+            any::rmarkdown
+            any::cranlogs
+            any::data.table
+            any::ggplot2
+            any::plotly
+            any::hrbrthemes
+            any::extrafont
 
-        - name: Render CRAN downloads RMD
-          run: Rscript -e "rmarkdown::render('CRANdownloads.Rmd')"
+    - name: Render CRAN downloads RMD
+      run: Rscript -e "rmarkdown::render('CRANdownloads.Rmd')"
+
+    - name: Commit to repository
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add --all
+        git commit --allow-empty -m "[auto] Update CRAN downloads $(TZ=America/New_York date +'%Y-%m-%d %H:%M')"
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .RData
 .Ruserdata
 
-*.html
 *.zip
 
 #folders


### PR DESCRIPTION
This PR commits the rendered HTML file to the repository.

It doesn't seem like it's possible to skip this and programmatically upload the document to RPubs -- `markdown::rpubsUpload` comes close, but still requires someone to interact with the browser.

This action will automatically post to https://vlyubchich.github.io/CRANdownloads
You'll need to activate GitHub Pages for this repository: 
- "Settings" -> "Code and automation" -> "Pages"
- "Build and Deployment" -> "Source" -> "GitHub Actions"